### PR TITLE
Added a serial-over-socket interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/python
+.DS_Store

--- a/pytrinamic/connections/__init__.py
+++ b/pytrinamic/connections/__init__.py
@@ -3,6 +3,7 @@ from .can_tmcl.pcan_tmcl_interface import PcanTmclInterface
 from .can_tmcl.socketcan_tmcl_interface import SocketcanTmclInterface
 from .can_tmcl.kvaser_tmcl_interface import KvaserTmclInterface
 from .serial_tmcl_interface import SerialTmclInterface
+from .socket_tmcl_interface import SocketTmclInterface
 from .uart_ic_interface import UartIcInterface
 from .usb_tmcl_interface import UsbTmclInterface
 from .can_tmcl.slcan_tmcl_interface import SlcanTmclInterface

--- a/pytrinamic/connections/socket_tmcl_interface.py
+++ b/pytrinamic/connections/socket_tmcl_interface.py
@@ -113,8 +113,9 @@ class SocketTmclInterface(TmclInterface):
         try:
             data = self._socket.recvmsg(9)[0]
         except socket.timeout:
-            print(f'Data received: {type(data)=}' )            
-            print(" ".join("{:02x}".format(x) for x in data))
+            if ('data' in locals()):
+                print(f'Data received: {type(data)=}' )            
+                print(" ".join("{:02x}".format(x) for x in data))
             raise RuntimeError("TMCL datagram timed out")
 
         return data

--- a/pytrinamic/connections/socket_tmcl_interface.py
+++ b/pytrinamic/connections/socket_tmcl_interface.py
@@ -8,6 +8,8 @@ Adapting it to follow the structure of serial_tmcl_interface.py and socketcan_tm
 """
 
 import logging
+
+import numpy as np
 from .tmcl_interface import TmclInterface
 from ..tmcl import TMCLReplyChecksumError
 import re
@@ -83,7 +85,7 @@ class SocketTmclInterface(TmclInterface):
         self.close()
 
     def close(self):
-        self.logger.info("Closing Socket Connection")
+        # self.logger.info("Closing Socket Connection")
         self._socket.close()
 
     def _send(self, host_id, module_id, data):
@@ -95,6 +97,8 @@ class SocketTmclInterface(TmclInterface):
         """
         del host_id, module_id
         self._check_socket()
+        # print('Sending data:')
+        # print(" ".join("{:02x}".format(x) for x in data))
         self._socket.sendall(data)
 
     def _recv(self, host_id, module_id):
@@ -106,8 +110,11 @@ class SocketTmclInterface(TmclInterface):
         """
         del host_id, module_id
         self._check_socket()
-        data = self._socket.recv(9)
-        if len(data) != 9:
+        try:
+            data = self._socket.recvmsg(9)[0]
+        except socket.timeout:
+            print(f'Data received: {type(data)=}' )            
+            print(" ".join("{:02x}".format(x) for x in data))
             raise RuntimeError("TMCL datagram timed out")
 
         return data

--- a/pytrinamic/connections/socket_tmcl_interface.py
+++ b/pytrinamic/connections/socket_tmcl_interface.py
@@ -1,0 +1,145 @@
+"""
+Created on 05.08.2020
+
+@author: SW
+BRP mod: Found this code on https://github.com/trinamic/PyTrinamic/blob/11c36a3d8d8333c1f21c7daee4e62eb4ff43892e/PyTrinamic/connections/socket_tmcl_interface.py
+Seems to be a dead branch left by someone else, but implementing what I need. 
+Adapting it to follow the structure of serial_tmcl_interface.py and socketcan_tmcl_interface.py
+"""
+
+import logging
+from .tmcl_interface import TmclInterface
+from ..tmcl import TMCLReplyChecksumError
+import re
+import socket
+
+
+class SocketTmclInterface(TmclInterface):
+    """
+    This class implements a TMCL connection over a Socket, for use with e.g. an ethernet-to-serial converter further down the line.
+    """
+
+    _CHANNELS = []
+    _socket = None
+
+    # mod from socketcan_tmcl_interface.py and serial_tmcl_interface.py
+    def __init__(
+        self,
+        ip_and_port: str,
+        datarate: int = 1000000,
+        host_id: int = 2,
+        module_id: int = 1,
+        timeout_s: int = 5,
+    ):
+        if not isinstance(ip_and_port, str):
+            raise TypeError
+
+        match = re.match(
+            '^"?((?:[0-9]{1,3}\.){3}[0-9]{1,3}):([0-9]{1,5})"?$', ip_and_port
+        )
+        if match is None:
+            raise ValueError("Invalid ip:port combination")
+
+        self._socket_ip = match.group(1)
+        self._socket_port = int(match.group(2))
+        self._CHANNELS += [ip_and_port]
+        TmclInterface.__init__(self, host_id, module_id)
+
+        if timeout_s == 0:
+            timeout_s = None
+
+        self.logger = logging.getLogger(
+            "{}.{}".format(self.__class__.__name__, ip_and_port)
+        )
+
+        self.logger.debug(
+            f"Opening {self._socket_ip=} {self._socket_port=} for TMCL control"
+        )
+        self._check_socket()  # connect to the socket
+        self.set_timeout(timeout_s)
+
+    def _check_socket(self):
+        """
+        Check if the socket is still open. If not, try to reconnect. Not sure it is necessary here, but it helped in the past.
+        """
+        if self._socket is None:
+            try:
+                self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._socket.connect((self._socket_ip, self._socket_port))
+            except socket.error as e:
+                self._connection = None
+                raise ConnectionError(
+                    "Failed to (re-)connect to Socket connection"
+                ) from e
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exitType, value, traceback):
+        """
+        Close the connection at the end of a with-statement block.
+        """
+        del exitType, value, traceback
+        self.close()
+
+    def close(self):
+        self.logger.info("Closing Socket Connection")
+        self._socket.close()
+
+    def _send(self, host_id, module_id, data):
+        """
+        Send the bytearray parameter [data].
+
+        This is a required override function for using the tmcl_interface
+        class.
+        """
+        del host_id, module_id
+        self._check_socket()
+        self._socket.sendall(data)
+
+    def _recv(self, host_id, module_id):
+        """
+        Read 9 bytes and return them as a bytearray.
+
+        This is a required override function for using the tmcl_interface
+        class.
+        """
+        del host_id, module_id
+        self._check_socket()
+        data = self._socket.recv(9)
+        if len(data) != 9:
+            raise RuntimeError("TMCL datagram timed out")
+
+        return data
+
+    def _reply_check(self, reply):
+        if not reply.is_checksum_correct():
+            raise TMCLReplyChecksumError(reply)
+
+    def set_timeout(self, timeout):
+        self._socket.settimeout(timeout) if timeout != 0 else None
+
+    def get_timeout(self):
+        return self._socket.gettimeout()
+
+    @staticmethod
+    def supports_tmcl():
+        return True
+
+    @classmethod
+    def list(cls):
+        """
+        Return a list of available connection ports as a list of strings.
+
+        This function is required for using this interface with the
+        connection manager.
+        """
+        return cls._CHANNELS
+
+    def __str__(self):
+        print(
+            "Connection: type=socket_tmcl_interface ip="
+            + self._socket_ip
+            + " port="
+            + str(self._socket_port)
+        )


### PR DESCRIPTION
I have a TMCM board connected to a machine network via an ethernet-to-serial converter. These take socket connections and pass them on to the RS232 or (in my case) RS485 serial port. 

I found some old code in an abandoned branch on here, polished it up, and made it resemble the structure of the serial and socketcan connections. Given that someone else went down the same rabbit-hole a while ago, and since connecting motor controllers to a TCP/IP network like this is quite common in my experience, it might be of use to someone else. 

It has been tested with the following code block: 
```python
import pytrinamic
from pytrinamic.connections import ConnectionManager
from pytrinamic.modules import TMCM6214
import time
pytrinamic.show_info()
connectionManager=ConnectionManager("--interface socket_serial_tmcl --port 192.168.0.253:4016 --host-id 3 --module-id 0")
with connectionManager.connect() as myInterface:
    module = TMCM6214(myInterface)
    motor_0 = module.motors[0]
    print(motor_0.get_position_reached())
```